### PR TITLE
chore: update build configuration to ensure site is deployed correctly

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -1,0 +1,1 @@
+- [Vercel monorepo output dir](vercel-monorepo-output-dir.md) — "No Output Directory named public" despite correct vercel.json; fix = copy build output to repo-root /public, set outputDirectory: public.

--- a/.agents/memory/vercel-monorepo-output-dir.md
+++ b/.agents/memory/vercel-monorepo-output-dir.md
@@ -1,0 +1,36 @@
+---
+name: Vercel monorepo output directory
+description: Why a nested build output fails Vercel with "No Output Directory named public" and the deterministic fix
+---
+
+# Vercel "No Output Directory named public found" for monorepo sub-apps
+
+## Symptom
+Vercel build *succeeds* (the build command runs, vite emits files) but the deploy
+fails with: `Error: No Output Directory named "public" found after the Build completed.`
+This happens even when `vercel.json#outputDirectory` points at the correct nested
+path (e.g. `artifacts/<app>/dist/public`).
+
+## Why
+Vercel's dashboard "Build & Development Settings" can override `vercel.json` on a
+**per-field** basis (Override toggle). It's possible for `installCommand` and
+`buildCommand` from `vercel.json` to be honored while `outputDirectory` is
+overridden by the dashboard's default (`public`). So the file looks correct but
+the effective output dir is the generic default. You cannot see or reliably fix
+this from code, and telling the user to change the dashboard is unreliable.
+
+## Deterministic fix (code-only, dashboard-independent)
+Make the output land where Vercel looks by default — repo-root `public/`:
+- `buildCommand`: append `&& rm -rf public && cp -r <app>/dist/public public`
+- `outputDirectory`: `public`
+- Add `/public` to root `.gitignore` (build artifact, regenerated each deploy).
+
+**Why it's bulletproof:** whether Vercel uses our `outputDirectory: public` OR its
+own default `public`, the files are in the same place. Do NOT change vite's
+`build.outDir` — it stays `dist/public` because the Replit artifact serve config
+depends on it; the copy shim only affects Vercel.
+
+## Note on this repo's vite config
+`artifacts/pk-site/vite.config.ts` THROWS if `PORT` or `BASE_PATH` is unset, so the
+Vercel `buildCommand` inlines `BASE_PATH=/ PORT=5173`. A build that completes is
+proof those env vars were set (i.e. our buildCommand ran).

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Thumbs.db
 # Replit
 .cache/
 .local/
+
+# Vercel deploy output shim
+/public

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile --prod=false",
-  "buildCommand": "BASE_PATH=/ PORT=5173 pnpm --filter @workspace/pk-site run build",
-  "outputDirectory": "artifacts/pk-site/dist/public",
+  "buildCommand": "BASE_PATH=/ PORT=5173 pnpm --filter @workspace/pk-site run build && rm -rf public && cp -r artifacts/pk-site/dist/public public",
+  "outputDirectory": "public",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
Modify the build command and output directory settings in vercel.json to ensure the site is consistently deployed to the 'public' directory, and add '/public' to .gitignore.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 1d64bc6d-ec94-4db3-96dc-30f52e3eda2a
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 91da958a-4bf4-457c-936f-3be55862e6e0
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/7a6a7330-1788-4039-ba12-942e17857d49/1d64bc6d-ec94-4db3-96dc-30f52e3eda2a/sTo1Kqm
Replit-Helium-Checkpoint-Created: true